### PR TITLE
Add support for anyOf schemas

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -178,10 +178,10 @@ const hasExpandableProperties = computed(() => {
       </CollapsibleTrigger>
       <CollapsibleContent v-if="isObjectOrArray" class="ml-2 pl-2 border-l border-l-solid">
         <Badge
-          v-if="props.property.meta?.isOneOf === true"
+          v-if="props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true"
           variant="outline"
         >
-          {{ $t('One of') }}
+          {{ props.property.meta?.isAnyOf === true ? $t('Any of') : $t('One of') }}
         </Badge>
 
         <div class="flex flex-col space-y-2">
@@ -192,7 +192,7 @@ const hasExpandableProperties = computed(() => {
             :schema="props.schema"
             :deep="props.deep - 1"
             :level="props.level + 1"
-            :open="childrenExpandState !== undefined ? childrenExpandState : subProperty?.meta?.isOneOf === true"
+            :open="childrenExpandState !== undefined ? childrenExpandState : (subProperty?.meta?.isOneOf === true || subProperty?.meta?.isAnyOf === true)"
             :expand-all="childrenExpandState"
           />
         </div>

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -42,6 +42,9 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
     if (isOneOfProperty(property)) {
       return resolveOneOfProperty(property, useExample)
     }
+    if (isAnyOfProperty(property)) {
+      return resolveAnyOfProperty(property, useExample)
+    }
     return uiPropertyObjectToJson(property.properties || [], useExample)
   }
 
@@ -51,6 +54,9 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
   if (isOneOfProperty(property)) {
     return [resolveOneOfProperty(property, useExample)]
+  }
+  if (isAnyOfProperty(property)) {
+    return [resolveAnyOfProperty(property, useExample)]
   }
 
   if (property.meta?.hasPrefixItems && property.properties && Array.isArray(property.properties)) {
@@ -159,7 +165,19 @@ function isOneOfProperty(property: OAProperty): boolean {
   return !!property.meta?.isOneOf && Array.isArray(property.properties)
 }
 
+function isAnyOfProperty(property: OAProperty): boolean {
+  return !!property.meta?.isAnyOf && Array.isArray(property.properties)
+}
+
 function resolveOneOfProperty(property: OAProperty, useExample: boolean): any {
+  if (property.properties && property.properties.length > 0) {
+    return uiPropertyToJson(property.properties[0], useExample)
+  } else {
+    return useExample ? getPropertyExample(property) : getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
+  }
+}
+
+function resolveAnyOfProperty(property: OAProperty, useExample: boolean): any {
   if (property.properties && property.properties.length > 0) {
     return uiPropertyToJson(property.properties[0], useExample)
   } else {

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -97,31 +97,53 @@ class UiPropertyFactory {
     }
   }
 
-  static createOneOfProperty(oneOfProperties: Partial<OpenAPI.SchemaObject>[], name: string = ''): OAProperty {
-    return {
+  static createOneOfProperty(
+    oneOfProperties: Partial<OpenAPI.SchemaObject>[],
+    name: string = '',
+    baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
+  ): OAProperty {
+    const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
+      baseSchema,
+      required,
+    )
+
+    return {
+      ...baseProperty,
       types: ['object'],
-      required: false,
+      required: baseProperty.required,
       properties: oneOfProperties.map((prop) => {
         const property = UiPropertyFactory.schemaToUiProperty('', prop)
         property.meta = { ...(property.meta || {}), isOneOfItem: true }
         return property
       }),
-      meta: { isOneOf: true },
+      meta: { ...(baseProperty.meta || {}), isOneOf: true },
     }
   }
 
-  static createAnyOfProperty(anyOfProperties: Partial<OpenAPI.SchemaObject>[], name: string = ''): OAProperty {
-    return {
+  static createAnyOfProperty(
+    anyOfProperties: Partial<OpenAPI.SchemaObject>[],
+    name: string = '',
+    baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
+  ): OAProperty {
+    const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
+      baseSchema,
+      required,
+    )
+
+    return {
+      ...baseProperty,
       types: ['object'],
-      required: false,
+      required: baseProperty.required,
       properties: anyOfProperties.map((prop) => {
         const property = UiPropertyFactory.schemaToUiProperty('', prop)
         property.meta = { ...(property.meta || {}), isAnyOfItem: true }
         return property
       }),
-      meta: { isAnyOf: true },
+      meta: { ...(baseProperty.meta || {}), isAnyOf: true },
     }
   }
 
@@ -143,11 +165,21 @@ class UiPropertyFactory {
     }
 
     if (schema.oneOf) {
-      return UiPropertyFactory.createOneOfProperty(schema.oneOf, name)
+      return UiPropertyFactory.createOneOfProperty(
+        schema.oneOf,
+        name,
+        schema,
+        required,
+      )
     }
 
     if (schema.anyOf) {
-      return UiPropertyFactory.createAnyOfProperty(schema.anyOf, name)
+      return UiPropertyFactory.createAnyOfProperty(
+        schema.anyOf,
+        name,
+        schema,
+        required,
+      )
     }
 
     if (schema.const !== undefined) {

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -447,6 +447,106 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'anyOf property with description': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          description: 'Some description here...',
+          anyOf: [
+            {
+              type: 'array',
+              items: { type: 'string' },
+            },
+            { type: 'null' },
+          ],
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          description: 'Some description here...',
+          types: ['object'],
+          required: false,
+          properties: [
+            {
+              name: '',
+              types: ['array'],
+              required: false,
+              subtype: 'string',
+              meta: { isAnyOfItem: true },
+            },
+            {
+              name: '',
+              types: ['null'],
+              required: false,
+              meta: { isAnyOfItem: true },
+            },
+          ],
+          meta: { isAnyOf: true },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: ['string'],
+    },
+  },
+
+  'oneOf property with description': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          description: 'Some description here...',
+          oneOf: [
+            {
+              type: 'array',
+              items: { type: 'string' },
+            },
+            { type: 'null' },
+          ],
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          description: 'Some description here...',
+          types: ['object'],
+          required: false,
+          properties: [
+            {
+              name: '',
+              types: ['array'],
+              required: false,
+              subtype: 'string',
+              meta: { isOneOfItem: true },
+            },
+            {
+              name: '',
+              types: ['null'],
+              required: false,
+              meta: { isOneOfItem: true },
+            },
+          ],
+          meta: { isOneOf: true },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: ['string'],
+    },
+  },
+
   'nested oneOf schema': {
     jsonSchema: {
       oneOf: [

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -367,6 +367,86 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'anyOf schema': {
+    jsonSchema: {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+          },
+          required: ['name'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+            addresses: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                },
+              },
+            },
+          },
+          required: ['name'],
+        },
+      ],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      properties: [
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+            {
+              name: 'addresses',
+              properties: [
+                { name: 'street', types: ['string'], required: false },
+              ],
+              required: false,
+              types: ['array'],
+              subtype: 'object',
+            },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+      ],
+      required: false,
+      meta: {
+        isAnyOf: true,
+      },
+    },
+    // Takes first anyOf schema as default.
+    schemaUiJson: {
+      name: 'string',
+      age: 0,
+    },
+  },
+
   'nested oneOf schema': {
     jsonSchema: {
       oneOf: [


### PR DESCRIPTION
## Summary
- handle `anyOf` definitions in `getSchemaUi`
- render `anyOf` blocks in schema viewer
- generate JSON examples for `anyOf`
- cover new behaviour with unit tests

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_6869333276a4832dac3ffdaa0b932312