### PR TITLE
Add support for anyOf schemas

### DIFF
--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -178,10 +178,10 @@ const hasExpandableProperties = computed(() => {
       </CollapsibleTrigger>
       <CollapsibleContent v-if="isObjectOrArray" class="ml-2 pl-2 border-l border-l-solid">
         <Badge
-          v-if="props.property.meta?.isOneOf === true"
+          v-if="props.property.meta?.isOneOf === true || props.property.meta?.isAnyOf === true"
           variant="outline"
         >
-          {{ $t('One of') }}
+          {{ props.property.meta?.isAnyOf === true ? $t('Any of') : $t('One of') }}
         </Badge>
 
         <div class="flex flex-col space-y-2">
@@ -192,7 +192,7 @@ const hasExpandableProperties = computed(() => {
             :schema="props.schema"
             :deep="props.deep - 1"
             :level="props.level + 1"
-            :open="childrenExpandState !== undefined ? childrenExpandState : subProperty?.meta?.isOneOf === true"
+            :open="childrenExpandState !== undefined ? childrenExpandState : (subProperty?.meta?.isOneOf === true || subProperty?.meta?.isAnyOf === true)"
             :expand-all="childrenExpandState"
           />
         </div>

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -38,17 +38,19 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
     }, useExample)
   }
 
+  if (isOneOfProperty(property)) {
+    return resolveOneOfProperty(property, useExample)
+  }
+
+  if (isAnyOfProperty(property)) {
+    return resolveAnyOfProperty(property, useExample)
+  }
+
   if (containsType(property, 'object')) {
-    if (isOneOfProperty(property)) {
-      return resolveOneOfProperty(property, useExample)
-    }
-    if (isAnyOfProperty(property)) {
-      return resolveAnyOfProperty(property, useExample)
-    }
     return uiPropertyObjectToJson(property.properties || [], useExample)
   }
 
-  return {}
+  return getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
 }
 
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {

--- a/src/lib/examples/getSchemaUiJson.ts
+++ b/src/lib/examples/getSchemaUiJson.ts
@@ -42,6 +42,9 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
     if (isOneOfProperty(property)) {
       return resolveOneOfProperty(property, useExample)
     }
+    if (isAnyOfProperty(property)) {
+      return resolveAnyOfProperty(property, useExample)
+    }
     return uiPropertyObjectToJson(property.properties || [], useExample)
   }
 
@@ -51,6 +54,9 @@ function uiPropertyToJson(property: OAProperty, useExample: boolean): any {
 function uiPropertyArrayToJson(property: OAProperty, useExample: boolean): any {
   if (isOneOfProperty(property)) {
     return [resolveOneOfProperty(property, useExample)]
+  }
+  if (isAnyOfProperty(property)) {
+    return [resolveAnyOfProperty(property, useExample)]
   }
 
   if (property.meta?.hasPrefixItems && property.properties && Array.isArray(property.properties)) {
@@ -159,7 +165,19 @@ function isOneOfProperty(property: OAProperty): boolean {
   return !!property.meta?.isOneOf && Array.isArray(property.properties)
 }
 
+function isAnyOfProperty(property: OAProperty): boolean {
+  return !!property.meta?.isAnyOf && Array.isArray(property.properties)
+}
+
 function resolveOneOfProperty(property: OAProperty, useExample: boolean): any {
+  if (property.properties && property.properties.length > 0) {
+    return uiPropertyToJson(property.properties[0], useExample)
+  } else {
+    return useExample ? getPropertyExample(property) : getDefaultValueForType(property.types[0] ?? 'string', property.defaultValue)
+  }
+}
+
+function resolveAnyOfProperty(property: OAProperty, useExample: boolean): any {
   if (property.properties && property.properties.length > 0) {
     return uiPropertyToJson(property.properties[0], useExample)
   } else {

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -104,9 +104,21 @@ class UiPropertyFactory {
   ): OAProperty {
     const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
-      { ...baseSchema, type: 'object' },
+      baseSchema,
       false,
     )
+
+    const unionTypes = Array.from(
+      new Set(
+        oneOfProperties
+          .map(prop => determineSchemaType(prop as OpenAPI.SchemaObject))
+          .filter(Boolean),
+      ),
+    ) as JSONSchemaType[]
+
+    if (unionTypes.length > 0) {
+      baseProperty.types = unionTypes
+    }
 
     baseProperty.properties = oneOfProperties.map((prop) => {
       const property = UiPropertyFactory.schemaToUiProperty('', prop)
@@ -126,9 +138,21 @@ class UiPropertyFactory {
   ): OAProperty {
     const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
-      { ...baseSchema, type: 'object' },
+      baseSchema,
       false,
     )
+
+    const unionTypes = Array.from(
+      new Set(
+        anyOfProperties
+          .map(prop => determineSchemaType(prop as OpenAPI.SchemaObject))
+          .filter(Boolean),
+      ),
+    ) as JSONSchemaType[]
+
+    if (unionTypes.length > 0) {
+      baseProperty.types = unionTypes
+    }
 
     baseProperty.properties = anyOfProperties.map((prop) => {
       const property = UiPropertyFactory.schemaToUiProperty('', prop)

--- a/src/lib/parser/getSchemaUi.ts
+++ b/src/lib/parser/getSchemaUi.ts
@@ -101,11 +101,12 @@ class UiPropertyFactory {
     oneOfProperties: Partial<OpenAPI.SchemaObject>[],
     name = '',
     baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
   ): OAProperty {
     const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
       baseSchema,
-      false,
+      required,
     )
 
     const unionTypes = Array.from(
@@ -135,11 +136,12 @@ class UiPropertyFactory {
     anyOfProperties: Partial<OpenAPI.SchemaObject>[],
     name = '',
     baseSchema: Partial<OpenAPI.SchemaObject> = {},
+    required = false,
   ): OAProperty {
     const baseProperty = UiPropertyFactory.createBaseProperty(
       name,
       baseSchema,
-      false,
+      required,
     )
 
     const unionTypes = Array.from(
@@ -183,11 +185,11 @@ class UiPropertyFactory {
     }
 
     if (schema.oneOf) {
-      return UiPropertyFactory.createOneOfProperty(schema.oneOf, name, schema)
+      return UiPropertyFactory.createOneOfProperty(schema.oneOf, name, schema, required)
     }
 
     if (schema.anyOf) {
-      return UiPropertyFactory.createAnyOfProperty(schema.anyOf, name, schema)
+      return UiPropertyFactory.createAnyOfProperty(schema.anyOf, name, schema, required)
     }
 
     if (schema.const !== undefined) {

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -367,6 +367,146 @@ const fixtures: Record<string, FixtureTest> = {
     },
   },
 
+  'anyOf schema': {
+    jsonSchema: {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+          },
+          required: ['name'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'integer' },
+            addresses: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  street: { type: 'string' },
+                },
+              },
+            },
+          },
+          required: ['name'],
+        },
+      ],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      properties: [
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+        {
+          name: '',
+          properties: [
+            { name: 'name', types: ['string'], required: true },
+            { name: 'age', types: ['integer'], required: false },
+            {
+              name: 'addresses',
+              properties: [
+                { name: 'street', types: ['string'], required: false },
+              ],
+              required: false,
+              types: ['array'],
+              subtype: 'object',
+            },
+          ],
+          types: ['object'],
+          required: false,
+          meta: {
+            isAnyOfItem: true,
+          },
+        },
+      ],
+      required: false,
+      meta: {
+        isAnyOf: true,
+      },
+    },
+    // Takes first anyOf schema as default.
+    schemaUiJson: {
+      name: 'string',
+      age: 0,
+    },
+  },
+
+  'anyOf schema with description': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          anyOf: [
+            {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            {
+              type: 'null',
+            },
+          ],
+          description: 'Some description here...',
+        },
+      },
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          types: ['object'],
+          required: false,
+          description: 'Some description here...',
+          properties: [
+            {
+              name: '',
+              types: ['array'],
+              required: false,
+              subtype: 'string',
+              meta: {
+                isAnyOfItem: true,
+              },
+            },
+            {
+              name: '',
+              types: ['null'],
+              required: false,
+              meta: {
+                isAnyOfItem: true,
+              },
+            },
+          ],
+          meta: {
+            isAnyOf: true,
+          },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: ['string'],
+    },
+  },
+
   'nested oneOf schema': {
     jsonSchema: {
       oneOf: [

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -474,7 +474,7 @@ const fixtures: Record<string, FixtureTest> = {
       properties: [
         {
           name: 'foo',
-          types: ['object'],
+          types: ['array', 'null'],
           required: false,
           description: 'Some description here...',
           properties: [

--- a/test/lib/processOpenAPI/getSchemaUi.test.ts
+++ b/test/lib/processOpenAPI/getSchemaUi.test.ts
@@ -466,6 +466,7 @@ const fixtures: Record<string, FixtureTest> = {
           description: 'Some description here...',
         },
       },
+      required: ['foo'],
     },
     schemaUi: {
       name: '',
@@ -475,7 +476,7 @@ const fixtures: Record<string, FixtureTest> = {
         {
           name: 'foo',
           types: ['array', 'null'],
-          required: false,
+          required: true,
           description: 'Some description here...',
           properties: [
             {
@@ -504,6 +505,41 @@ const fixtures: Record<string, FixtureTest> = {
     },
     schemaUiJson: {
       foo: ['string'],
+    },
+  },
+
+  'required oneOf property': {
+    jsonSchema: {
+      type: 'object',
+      properties: {
+        foo: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'null' },
+          ],
+        },
+      },
+      required: ['foo'],
+    },
+    schemaUi: {
+      name: '',
+      types: ['object'],
+      required: false,
+      properties: [
+        {
+          name: 'foo',
+          types: ['string', 'null'],
+          required: true,
+          properties: [
+            { name: '', types: ['string'], required: false, meta: { isOneOfItem: true } },
+            { name: '', types: ['null'], required: false, meta: { isOneOfItem: true } },
+          ],
+          meta: { isOneOf: true },
+        },
+      ],
+    },
+    schemaUiJson: {
+      foo: 'string',
     },
   },
 


### PR DESCRIPTION
## Summary
- handle `anyOf` definitions in `getSchemaUi`
- render `anyOf` blocks in schema viewer
- generate JSON examples for `anyOf`
- cover new behaviour with unit tests
- preserve descriptions when `anyOf` or `oneOf` are used

## Testing
- `pnpm test:run`
- `pnpm -w run typecheck`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6869333276a4832dac3ffdaa0b932312