### PR TITLE
Fix path metadata handling in parser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,17 @@ export { usePaths } from './composables/usePaths'
 export { useSidebar } from './composables/useSidebar'
 export { OpenApi } from './lib/OpenApi'
 
-export const httpVerbs = ['get', 'post', 'put', 'delete', 'patch', 'options', 'head']
+import { OpenAPIV3 } from '@scalar/openapi-types'
+
+export const httpVerbs: readonly OpenAPIV3.HttpMethods[] = [
+  OpenAPIV3.HttpMethods.GET,
+  OpenAPIV3.HttpMethods.POST,
+  OpenAPIV3.HttpMethods.PUT,
+  OpenAPIV3.HttpMethods.DELETE,
+  OpenAPIV3.HttpMethods.PATCH,
+  OpenAPIV3.HttpMethods.OPTIONS,
+  OpenAPIV3.HttpMethods.HEAD,
+  OpenAPIV3.HttpMethods.TRACE,
+]
 
 export const literalTypes = ['string', 'number', 'integer', 'boolean', 'null']

--- a/src/lib/parser/generateCodeSamples.ts
+++ b/src/lib/parser/generateCodeSamples.ts
@@ -4,6 +4,7 @@ import { availableLanguages, useTheme } from '../../composables/useTheme'
 import { buildRequest } from '../codeSamples/buildRequest'
 import { generateCodeSample } from '../codeSamples/generateCodeSample'
 import { resolveBaseUrl } from '../resolveBaseUrl'
+import { httpVerbs } from '../../index'
 
 export async function generateCodeSamples(spec: ParsedOpenAPI): Promise<ParsedOpenAPI> {
   if (!spec?.paths) {
@@ -13,8 +14,8 @@ export async function generateCodeSamples(spec: ParsedOpenAPI): Promise<ParsedOp
   const baseUrl = resolveBaseUrl(spec.servers?.[0]?.url || '')
 
   for (const [path, pathObject] of Object.entries(spec.paths)) {
-    for (const verb of Object.keys(pathObject) as OpenAPIV3.HttpMethods[]) {
-      const operation = pathObject[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (pathObject as Record<string, any>)[verb] as ParsedOperation
 
       if (!operation) {
         continue

--- a/src/lib/parser/generateMissingOperationIds.ts
+++ b/src/lib/parser/generateMissingOperationIds.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingOperationIds(spec: OpenAPIDocument): OpenAPIDocument {
   spec.paths = spec.paths || {}
@@ -7,8 +8,12 @@ export function generateMissingOperationIds(spec: OpenAPIDocument): OpenAPIDocum
   for (const path of Object.keys(spec.paths)) {
     const pathValue = spec.paths[path] as Record<string, OpenAPIV3.OperationObject>
 
-    for (const verb of Object.keys(pathValue) as OpenAPIV3.HttpMethods[]) {
+    for (const verb of httpVerbs) {
       const operation = pathValue[verb]
+
+      if (!operation) {
+        continue
+      }
 
       if (!operation.operationId) {
         operation.operationId = `${verb}${path.replace(/\//g, '-')}`

--- a/src/lib/parser/generateMissingSummary.ts
+++ b/src/lib/parser/generateMissingSummary.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument, OperationObject } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingSummary(spec: OpenAPIDocument): OpenAPIDocument {
   spec.paths = spec.paths || {}
@@ -7,8 +8,12 @@ export function generateMissingSummary(spec: OpenAPIDocument): OpenAPIDocument {
   for (const path of Object.keys(spec.paths)) {
     const pathValue = spec.paths[path] as Record<string, OperationObject>
 
-    for (const verb of Object.keys(pathValue) as OpenAPIV3.HttpMethods[]) {
+    for (const verb of httpVerbs) {
       const operation = pathValue[verb] as OperationObject
+
+      if (!operation) {
+        continue
+      }
 
       if (!operation.summary) {
         operation.summary = `${verb.toUpperCase()} ${path}`

--- a/src/lib/parser/generateMissingTags.ts
+++ b/src/lib/parser/generateMissingTags.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OpenAPIDocument } from '../../types'
+import { httpVerbs } from '../../index'
 
 export function generateMissingTags({
   spec,
@@ -14,8 +15,8 @@ export function generateMissingTags({
 
   spec.paths = spec.paths || {}
 
-  for (const [_, pathObject] of Object.entries(spec.paths)) {
-    for (const verb of Object.keys(pathObject as any) as OpenAPIV3.HttpMethods[]) {
+  for (const [, pathObject] of Object.entries(spec.paths)) {
+    for (const verb of httpVerbs) {
       if (!pathObject || !pathObject[verb]) {
         continue
       }

--- a/src/lib/parser/generateRequestBodyUi.ts
+++ b/src/lib/parser/generateRequestBodyUi.ts
@@ -1,6 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
+import { httpVerbs } from '../../index'
 
 export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {
@@ -8,9 +9,12 @@ export function generateRequestBodyUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path)) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
+      if (!operation) {
+        continue
+      }
       if (!operation.requestBody) {
         continue
       }

--- a/src/lib/parser/generateResponseUi.ts
+++ b/src/lib/parser/generateResponseUi.ts
@@ -1,6 +1,7 @@
 import type { ParsedContent, ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSchemaExample } from '../examples/getSchemaExample'
 import { getSchemaUi } from './getSchemaUi'
+import { httpVerbs } from '../../index'
 
 export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec.paths) {
@@ -8,9 +9,12 @@ export function generateResponseUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path)) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
+      if (!operation) {
+        continue
+      }
       if (!operation.responses) {
         continue
       }

--- a/src/lib/parser/generateSecurityUi.ts
+++ b/src/lib/parser/generateSecurityUi.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { ParsedOpenAPI, ParsedOperation } from '../../types'
 import { getSecurityUi } from './getSecurityUi'
+import { httpVerbs } from '../../index'
 
 export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   if (!spec?.paths) {
@@ -8,13 +9,12 @@ export function generateSecurityUi(spec: ParsedOpenAPI): ParsedOpenAPI {
   }
 
   for (const path of Object.values(spec.paths)) {
-    for (const verb of Object.keys(path) as OpenAPIV3.HttpMethods[]) {
-      const operation = path[verb] as ParsedOperation
+    for (const verb of httpVerbs) {
+      const operation = (path as Record<string, any>)[verb] as ParsedOperation
 
       if (!operation) {
         continue
       }
-
       operation.securityUi = getSecurityUi(operation.security ?? spec.security ?? [], spec.components?.securitySchemes || {})
     }
   }

--- a/test/lib/prepareOpenAPI/generateMissingOperationIds.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingOperationIds.test.ts
@@ -67,4 +67,22 @@ describe('generateMissingOperationIds', () => {
     const result = generateMissingOperationIds(input)
     expect(result).toEqual(input)
   })
+
+  it('ignores non-verb fields in path objects', () => {
+    const input = {
+      paths: {
+        '/example': {
+          summary: 'Example endpoint',
+          description: 'More info',
+          get: {},
+        },
+      },
+    }
+
+    const result = generateMissingOperationIds(input)
+
+    expect(result.paths['/example'].summary).toBe('Example endpoint')
+    expect(result.paths['/example'].description).toBe('More info')
+    expect(result.paths['/example'].get.operationId).toBe('get-example')
+  })
 })

--- a/test/lib/prepareOpenAPI/generateMissingSummary.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingSummary.test.ts
@@ -53,4 +53,22 @@ describe('generateMissingSummary', () => {
     const result = generateMissingSummary(value)
     expect(result.paths).toEqual({})
   })
+
+  it('ignores non-verb fields in path objects', () => {
+    const value = {
+      paths: {
+        '/item': {
+          summary: 'Item summary',
+          description: 'desc',
+          get: {},
+        },
+      },
+    }
+
+    const result = generateMissingSummary(value)
+
+    expect(result.paths['/item'].summary).toBe('Item summary')
+    expect(result.paths['/item'].description).toBe('desc')
+    expect(result.paths['/item'].get.summary).toBe('GET /item')
+  })
 })

--- a/test/lib/prepareOpenAPI/generateMissingTags.test.ts
+++ b/test/lib/prepareOpenAPI/generateMissingTags.test.ts
@@ -92,4 +92,17 @@ describe('generateMissingTags', () => {
       description: 'Custom Description',
     }])
   })
+  it('ignores non-verb fields in path objects', () => {
+    const spec = {
+      paths: {
+        '/example': {
+          summary: 'Some summary',
+          get: {},
+        },
+      },
+    }
+    const result = generateMissingTags({ spec })
+    expect(result.paths['/example'].summary).toBe('Some summary')
+    expect(result.paths['/example'].get.tags).toEqual(['Default'])
+  })
 })

--- a/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
+++ b/test/lib/processOpenAPI/parseOpenapi.pathMetadata.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { parseOpenapi } from '../../../src/lib/parser/parseOpenapi'
+
+const spec = {
+  openapi: '3.0.0',
+  info: { title: 'Test', version: '1.0.0' },
+  paths: {
+    '/example': {
+      summary: 'Example summary',
+      description: 'Example description',
+      get: {
+        responses: {
+          '200': { description: 'OK' },
+        },
+      },
+    },
+  },
+}
+
+describe('parseOpenapi with path metadata', () => {
+  it('processes paths containing summary or description', () => {
+    const result = parseOpenapi().parseSync({ spec })
+    expect(result.paths['/example'].summary).toBe('Example summary')
+    expect(result.paths['/example'].description).toBe('Example description')
+    expect(result.paths['/example'].get.operationId).toBe('get-example')
+    expect(result.paths['/example'].get.summary).toBe('GET /example')
+  })
+})


### PR DESCRIPTION
## Summary
- ignore `summary` and `description` path metadata when iterating operations
- import `httpVerbs` in parser utilities to filter valid methods
- strongly type `httpVerbs` to use OpenAPI enums
- add tests for path metadata handling

## Testing
- `pnpm build`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_686a3ab2a558832d9748052cf4a4419d