### PR TITLE
Use injected i18n in components

### DIFF
--- a/src/components/Common/OAFooter.vue
+++ b/src/components/Common/OAFooter.vue
@@ -1,9 +1,12 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
+
+const { t } = useI18n()
 </script>
 
 <template>
   <span class="text-sm text-muted-foreground text-center">
-    {{ $t('Powered by') }} <a
+    {{ t('Powered by') }} <a
       href="https://github.com/enzonotario/vitepress-openapi"
       target="_blank"
       class="text-primary-foreground"

--- a/src/components/Common/OAHeaderBadges.vue
+++ b/src/components/Common/OAHeaderBadges.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import { Badge } from '../ui/badge'
@@ -15,6 +16,8 @@ const { deprecated } = defineProps({
 })
 
 const themeConfig = useTheme()
+
+const { t } = useI18n()
 
 const operationBadges = computed(() => themeConfig.getOperationBadges().filter((badge) => {
   if (badge === 'deprecated' && !deprecated) {
@@ -33,11 +36,11 @@ const operationBadges = computed(() => themeConfig.getOperationBadges().filter((
       variant="outline"
     >
       <template v-if="badge === 'deprecated'">
-        {{ $t('Deprecated') }}
+        {{ t('Deprecated') }}
       </template>
 
       <template v-else-if="badge === 'operationId'">
-        {{ $t('operation.badgePrefix.operationId') }}{{ operation.operationId }}
+        {{ t('operation.badgePrefix.operationId') }}{{ operation.operationId }}
       </template>
     </Badge>
   </div>

--- a/src/components/Feature/OADownloadSpec.vue
+++ b/src/components/Feature/OADownloadSpec.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import yaml from 'js-yaml'
 import { Badge } from '../ui/badge/index'
 
@@ -8,6 +9,8 @@ const props = defineProps({
     required: true,
   },
 })
+
+const { t } = useI18n()
 
 function downloadSpec(format: 'json' | 'yaml'): void {
   try {
@@ -55,7 +58,7 @@ function downloadSpec(format: 'json' | 'yaml'): void {
       aria-label="Download OpenAPI Document as JSON"
       @click.prevent="downloadSpec('json')"
     >
-      <span class="underline mr-2">{{ $t('Download OpenAPI Document') }}</span>
+      <span class="underline mr-2">{{ t('Download OpenAPI Document') }}</span>
       <Badge variant="outline" class="hidden group-hover:inline-block">JSON</Badge>
     </a>
 
@@ -65,7 +68,7 @@ function downloadSpec(format: 'json' | 'yaml'): void {
       aria-label="Download OpenAPI Document as YAML"
       @click.prevent="downloadSpec('yaml')"
     >
-      <span class="underline mr-2">{{ $t('Download OpenAPI Document') }}</span>
+      <span class="underline mr-2">{{ t('Download OpenAPI Document') }}</span>
       <Badge variant="outline">YAML</Badge>
     </a>
   </div>

--- a/src/components/Feature/OAInfoContent.vue
+++ b/src/components/Feature/OAInfoContent.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { useTheme } from '../../composables/useTheme'
 import OAHeading from '../Common/OAHeading.vue'
 import OAMarkdown from '../Common/OAMarkdown.vue'
@@ -13,6 +14,7 @@ const props = defineProps({
 })
 
 const themeConfig = useTheme()
+const { t } = useI18n()
 const info = props.openapi.spec.info ?? {}
 
 const externalDocs = props.openapi.spec.externalDocs ?? {}
@@ -31,7 +33,7 @@ const externalDocs = props.openapi.spec.externalDocs ?? {}
       </div>
 
       <OAHeading level="h1">
-        {{ info.title ?? $t('API Documentation') }}
+        {{ info.title ?? t('API Documentation') }}
       </OAHeading>
 
       <OADownloadSpec
@@ -53,13 +55,13 @@ const externalDocs = props.openapi.spec.externalDocs ?? {}
 
     <template v-if="info.contact">
       <OAHeading level="h2">
-        {{ $t('Contact') }}
+        {{ t('Contact') }}
       </OAHeading>
 
       <div class="flex flex-row items-center gap-2">
         <template v-if="info.contact.url">
-          <a :href="info.contact.url" :aria-label="info.contact.name ?? $t('Contact')">
-            {{ info.contact.name ?? $t('Contact') }}
+          <a :href="info.contact.url" :aria-label="info.contact.name ?? t('Contact')">
+            {{ info.contact.name ?? t('Contact') }}
           </a>
 
           <span v-if="info.contact.email" class="text-muted-foreground">/</span>
@@ -74,7 +76,7 @@ const externalDocs = props.openapi.spec.externalDocs ?? {}
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
       <div v-if="info.termsOfService">
         <OAHeading level="h2">
-          {{ $t('Terms of Service') }}
+          {{ t('Terms of Service') }}
         </OAHeading>
 
         <a :href="info.termsOfService" :aria-label="info.termsOfService">
@@ -84,22 +86,22 @@ const externalDocs = props.openapi.spec.externalDocs ?? {}
 
       <div v-if="info.license">
         <OAHeading level="h2">
-          {{ $t('License') }}
+          {{ t('License') }}
         </OAHeading>
 
         <a :href="info.license.url" :aria-label="info.license.name">
-          {{ info.license.name ?? $t('License') }}
+          {{ info.license.name ?? t('License') }}
         </a>
       </div>
     </div>
 
     <template v-if="Object.keys(externalDocs).length">
       <OAHeading level="h2">
-        {{ $t('External Documentation') }}
+        {{ t('External Documentation') }}
       </OAHeading>
 
-      <a :href="externalDocs.url" :aria-label="externalDocs.description ?? $t('External Documentation')">
-        {{ externalDocs.description ?? $t('External Documentation') }}
+      <a :href="externalDocs.url" :aria-label="externalDocs.description ?? t('External Documentation')">
+        {{ externalDocs.description ?? t('External Documentation') }}
       </a>
     </template>
   </div>

--- a/src/components/Feature/OAOperationContent.vue
+++ b/src/components/Feature/OAOperationContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { OperationSlot } from '../../types'
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed } from 'vue'
 import OAFooter from '../Common/OAFooter.vue'
 import OAHeaderBadges from '../Common/OAHeaderBadges.vue'
@@ -53,6 +54,8 @@ const props = defineProps({
 })
 
 const slots = defineSlots<Record<string, OperationSlot>>()
+
+const { t } = useI18n()
 
 const operation = props.openapi.getOperation(props.operationId)
 
@@ -189,7 +192,7 @@ function hasSlot(name: OperationSlot): boolean {
         level="h2"
         :prefix="headingPrefix"
       >
-        {{ $t('Parameters') }}
+        {{ t('Parameters') }}
       </OAHeading>
 
       <OAParameters
@@ -313,7 +316,7 @@ function hasSlot(name: OperationSlot): boolean {
         level="h2"
         :prefix="headingPrefix"
       >
-        {{ $t('Samples') }}
+        {{ t('Samples') }}
       </OAHeading>
 
       <OACodeSamples

--- a/src/components/Feature/OAServersContent.vue
+++ b/src/components/Feature/OAServersContent.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import OAHeading from '../Common/OAHeading.vue'
 
 const props = defineProps({
@@ -9,12 +10,13 @@ const props = defineProps({
 })
 
 const servers = props.openapi.spec.servers ?? []
+const { t } = useI18n()
 </script>
 
 <template>
   <div>
     <OAHeading level="h2">
-      {{ $t('Servers') }}
+      {{ t('Servers') }}
     </OAHeading>
 
     <div class="flex flex-col space-y-4">

--- a/src/components/Operation/OAOperationTags.vue
+++ b/src/components/Operation/OAOperationTags.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { useTheme } from '../../composables/useTheme'
 import { Badge } from '../ui/badge'
 
@@ -7,6 +8,7 @@ const props = defineProps<{
 }>()
 
 const themeConfig = useTheme()
+const { t } = useI18n()
 
 const prefix = themeConfig.getTagsLinkPrefix()
 </script>
@@ -17,7 +19,7 @@ const prefix = themeConfig.getTagsLinkPrefix()
       v-for="(tag, index) in props.tags"
       :key="index"
       :href="`${prefix}${tag}`"
-      :aria-label="$t('tags.goTo', { tag })"
+      :aria-label="t('tags.goTo', { tag })"
     >
       <Badge variant="outline">
         {{ tag }}

--- a/src/components/Parameter/OAParameter.vue
+++ b/src/components/Parameter/OAParameter.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { getConstraints } from '../../lib/parser/constraintsParser'
 import OACodeValue from '../Common/OACodeValue.vue'
 import OAMarkdown from '../Common/OAMarkdown.vue'
@@ -13,6 +14,7 @@ const props = defineProps({
 })
 
 const constraints = getConstraints(props.parameter.schema)
+const { t } = useI18n()
 </script>
 
 <template>
@@ -40,7 +42,7 @@ const constraints = getConstraints(props.parameter.schema)
       <div class="flex flex-row gap-2">
         <OAParameterAttribute
           v-if="props.parameter.schema.type"
-          :name="$t('Type')"
+          :name="t('Type')"
           :value="props.parameter.schema.type"
           bold-name
         />
@@ -48,10 +50,10 @@ const constraints = getConstraints(props.parameter.schema)
         <span
           v-if="props.parameter.required"
           class="text-sm text-destructive"
-        >{{ $t('Required') }}</span>
+        >{{ t('Required') }}</span>
       </div>
 
-      <OAParameterAttribute v-if="props.parameter.schema.enum" :name="$t('Enum')" :value="props.parameter.schema.enum.join(', ')">
+      <OAParameterAttribute v-if="props.parameter.schema.enum" :name="t('Enum')" :value="props.parameter.schema.enum.join(', ')">
         <template #value>
           <div class="flex flex-wrap gap-2">
             <OACodeValue

--- a/src/components/Parameter/OAParameterExamples.vue
+++ b/src/components/Parameter/OAParameterExamples.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { useTheme } from '../../composables/useTheme'
 import { getPropertyExamples } from '../../lib/examples/getPropertyExamples'
 import OACodeValue from '../Common/OACodeValue.vue'
@@ -14,6 +15,7 @@ const props = defineProps({
 const examples = getPropertyExamples(props.property)
 
 const wrapExamples = useTheme().getWrapExamples()
+const { t } = useI18n()
 </script>
 
 <template>
@@ -21,7 +23,7 @@ const wrapExamples = useTheme().getWrapExamples()
     v-if="examples?.length === 1"
     class="flex flex-row space-x-2"
   >
-    <span class="text-sm">{{ $t('Example') }}</span>
+    <span class="text-sm">{{ t('Example') }}</span>
     <OACodeValue :value="examples[0]" />
   </div>
   <div
@@ -31,7 +33,7 @@ const wrapExamples = useTheme().getWrapExamples()
       'items-center': wrapExamples,
     }"
   >
-    <OAParameterAttribute :name="$t('Examples')">
+    <OAParameterAttribute :name="t('Examples')">
       <template #value>
         <div
           class="flex gap-2"

--- a/src/components/Parameter/OAParameters.vue
+++ b/src/components/Parameter/OAParameters.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { defineProps } from 'vue'
 import OAParameter from './OAParameter.vue'
 
@@ -18,6 +19,8 @@ const headerParameters = props.parameters.filter(parameter => parameter && param
 const pathParameters = props.parameters.filter(parameter => parameter && parameter.in === 'path')
 
 const queryParameters = props.parameters.filter(parameter => parameter && parameter.in === 'query')
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -27,7 +30,7 @@ const queryParameters = props.parameters.filter(parameter => parameter && parame
       class="space-y-4"
     >
       <h3>
-        {{ $t('Header Parameters') }}
+        {{ t('Header Parameters') }}
       </h3>
 
       <OAParameter
@@ -42,7 +45,7 @@ const queryParameters = props.parameters.filter(parameter => parameter && parame
       class="space-y-4"
     >
       <h3>
-        {{ $t('Path Parameters') }}
+        {{ t('Path Parameters') }}
       </h3>
 
       <OAParameter
@@ -57,7 +60,7 @@ const queryParameters = props.parameters.filter(parameter => parameter && parame
       class="space-y-4"
     >
       <h3>
-        {{ $t('Query Parameters') }}
+        {{ t('Query Parameters') }}
       </h3>
 
       <OAParameter

--- a/src/components/Path/OAPathEndpoint.vue
+++ b/src/components/Path/OAPathEndpoint.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import OAMethodBadge from '../Common/OAMethodBadge.vue'
 
 const props = defineProps({
@@ -27,13 +28,15 @@ const props = defineProps({
     required: false,
   },
 })
+
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="flex flex-col gap-2 text-sm bg-muted rounded p-1.5">
     <div class="language-bash !overflow-hidden !m-0 h-8 flex flex-row items-center gap-1.5">
       <button
-        :title="$t('Copy endpoint')"
+        :title="t('Copy endpoint')"
         class="copy absolute !top-1 z-50 OAPathEndpoint__copy"
       />
 

--- a/src/components/Path/OAPathsGroup.vue
+++ b/src/components/Path/OAPathsGroup.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { OperationSlot, PathsGroupView } from '../../types'
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, nextTick, ref } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import { scrollToHash } from '../../lib/utils'
@@ -20,6 +21,7 @@ const props = defineProps<Props>()
 const slots = defineSlots<Record<string, OperationSlot>>()
 
 const themeConfig = useTheme()
+const { t } = useI18n()
 
 const lazyRendering = themeConfig.getSpecConfig()?.lazyRendering?.value
 
@@ -69,7 +71,7 @@ function onPathClick(hash: string) {
       >
         <CollapsibleTrigger>
           <Button>
-            {{ isOpen ? $t('Hide operations') : $t('Show operations') }}
+            {{ isOpen ? t('Hide operations') : t('Show operations') }}
           </Button>
         </CollapsibleTrigger>
       </div>

--- a/src/components/Path/OAPathsSummary.vue
+++ b/src/components/Path/OAPathsSummary.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { defineProps } from 'vue'
 import OAHeading from '../Common/OAHeading.vue'
 
@@ -12,13 +13,15 @@ const { paths } = defineProps({
 const emit = defineEmits([
   'pathClick',
 ])
+
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="bg-muted rounded border divide-y divide-[var(--vp-c-divider)]">
     <div class="p-2 pl-4">
       <OAHeading level="h3" class="!mt-0 !text-sm">
-        {{ $t('Operations') }}
+        {{ t('Operations') }}
       </OAHeading>
     </div>
 

--- a/src/components/Playground/OAPlayground.vue
+++ b/src/components/Playground/OAPlayground.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { OperationData } from '../../lib/operationData'
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps, inject, onBeforeUnmount } from 'vue'
 import { usePlayground } from '../../composables/usePlayground'
 import { OPERATION_DATA_KEY } from '../../lib/operationData'
@@ -52,6 +53,7 @@ const props = defineProps({
 const { loading, response, submitRequest, cleanupImageUrls } = usePlayground()
 
 const operationData = inject(OPERATION_DATA_KEY) as OperationData
+const { t } = useI18n()
 
 const hasBody = computed(() =>
   Boolean(props.requestBody),
@@ -101,7 +103,7 @@ onBeforeUnmount(() => {
       :prefix="headingPrefix"
       class="block sm:hidden"
     >
-      {{ $t('Playground') }}
+      {{ t('Playground') }}
     </OAHeading>
 
     <OAPlaygroundParameters
@@ -119,7 +121,7 @@ onBeforeUnmount(() => {
 
     <div class="flex flex-col gap-2">
       <Button variant="primary" @click="onSubmit">
-        {{ $t('Try it out') }}
+        {{ t('Try it out') }}
       </Button>
 
       <OAPlaygroundResponse

--- a/src/components/Playground/OAPlaygroundParameterInput.vue
+++ b/src/components/Playground/OAPlaygroundParameterInput.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { defineEmits, defineProps, onMounted } from 'vue'
 import { getPropertyExample } from '../../lib/examples/getPropertyExample'
 import { Checkbox } from '../ui/checkbox'
@@ -63,6 +64,7 @@ onMounted(() => {
 })
 
 const parameterExample = getPropertyExample(props.parameter)
+const { t } = useI18n()
 </script>
 
 <template>
@@ -104,8 +106,8 @@ const parameterExample = getPropertyExample(props.parameter)
         :name="compositeKey"
         @update:model-value="handleInputChange($event)"
       >
-        <SelectTrigger :aria-label="String(parameterExample ?? $t('Select'))">
-          <SelectValue :placeholder="String(parameterExample ?? $t('Select'))" />
+        <SelectTrigger :aria-label="String(parameterExample ?? t('Select'))">
+          <SelectValue :placeholder="String(parameterExample ?? t('Select'))" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>

--- a/src/components/Playground/OAPlaygroundParameters.vue
+++ b/src/components/Playground/OAPlaygroundParameters.vue
@@ -3,6 +3,7 @@ import type { OpenAPIV3 } from '@scalar/openapi-types'
 import type { ComputedRef } from 'vue'
 import type { OperationData } from '../../lib/operationData'
 import type { PlaygroundSecurityScheme, SecurityUiItem } from '../../types'
+import { useI18n } from '@byjohann/vue-i18n'
 import { useStorage } from '@vueuse/core'
 import { computed, defineEmits, defineProps, inject, ref, watch } from 'vue'
 import { usePlayground } from '../../composables/usePlayground'
@@ -60,6 +61,7 @@ const emits = defineEmits([
 ])
 
 const operationData = inject(OPERATION_DATA_KEY) as OperationData
+const { t } = useI18n()
 
 const selectedServer = computed({
   get: () => operationData.playground.selectedServer.value,
@@ -198,7 +200,7 @@ watch(selectedSchemeId, (schemeId) => {
   <div class="OAPlaygroundParameters">
     <details v-if="serversUrls.length > 1 || allowCustomServer" open>
       <summary>
-        {{ $t('Server') }}
+        {{ t('Server') }}
       </summary>
 
       <div class="flex flex-col gap-2">
@@ -209,9 +211,9 @@ watch(selectedSchemeId, (schemeId) => {
           :default-custom-value="customServer"
           :options="serversUrls"
           :allow-custom-option="allowCustomServer"
-          :custom-option-label="$t('Custom Server')"
-          :custom-placeholder="$t('Enter a custom server URL')"
-          :placeholder="$t('Select a server')"
+          :custom-option-label="t('Custom Server')"
+          :custom-placeholder="t('Enter a custom server URL')"
+          :placeholder="t('Select a server')"
           @submit="emits('submit')"
         />
       </div>
@@ -219,14 +221,14 @@ watch(selectedSchemeId, (schemeId) => {
 
     <details v-if="authorizations?.length" open>
       <summary>
-        {{ $t('Authorization') }}
+        {{ t('Authorization') }}
         <div v-if="props.securityUi.length > 1" class="w-full max-w-[33%] md:max-w-[50%] ml-auto -mt-8">
           <Select v-model="selectedSchemeId">
             <SelectTrigger
               aria-label="Security Scheme"
               class="h-9 px-3 py-1.5 text-foreground font-normal"
             >
-              <SelectValue :placeholder="selectedSchemeId ?? $t('Select')" />
+              <SelectValue :placeholder="selectedSchemeId ?? t('Select')" />
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
@@ -267,7 +269,7 @@ watch(selectedSchemeId, (schemeId) => {
 
     <details v-if="headerParameters.length" open>
       <summary>
-        {{ $t('Headers') }}
+        {{ t('Headers') }}
       </summary>
 
       <div class="flex flex-col gap-2">
@@ -290,7 +292,7 @@ watch(selectedSchemeId, (schemeId) => {
 
     <details v-if="Object.keys(queryParameters).length || Object.keys(pathParameters).length" open>
       <summary>
-        {{ $t('Variables') }}
+        {{ t('Variables') }}
       </summary>
 
       <div class="flex flex-col gap-1">
@@ -298,10 +300,10 @@ watch(selectedSchemeId, (schemeId) => {
           <div class="w-[16px]" />
           <div class="flex flex-row flex-grow gap-2">
             <div class="w-1/2 flex justify-start">
-              <span class="text-xs text-muted-foreground uppercase">{{ $t('Key') }}</span>
+              <span class="text-xs text-muted-foreground uppercase">{{ t('Key') }}</span>
             </div>
             <div class="w-1/2 flex justify-start">
-              <span class="text-xs text-muted-foreground uppercase">{{ $t('Value') }}</span>
+              <span class="text-xs text-muted-foreground uppercase">{{ t('Value') }}</span>
             </div>
           </div>
         </div>
@@ -321,7 +323,7 @@ watch(selectedSchemeId, (schemeId) => {
 
     <details v-if="props.requestBody && selectedContentType" open>
       <summary>
-        {{ $t('Body') }}
+        {{ t('Body') }}
       </summary>
 
       <OAPlaygroundBodyInput

--- a/src/components/Playground/OAPlaygroundResponse.vue
+++ b/src/components/Playground/OAPlaygroundResponse.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { defineProps } from 'vue'
 import { Badge } from '../ui/badge'
 import OAPlaygroundResponseContent from './OAPlaygroundResponseContent.vue'
@@ -13,13 +14,15 @@ const { response, loading } = defineProps({
     default: false,
   },
 })
+
+const { t } = useI18n()
 </script>
 
 <template>
   <details v-if="response || loading" open>
     <summary class="!my-0 text-lg font-bold cursor-pointer">
       <div class="inline-flex items-center gap-2 w-[calc(100%-24px)]">
-        <span>{{ loading ? $t('Loading') : $t('Response') }}</span>
+        <span>{{ loading ? t('Loading') : t('Response') }}</span>
 
         <span class="flex-1" />
 
@@ -40,7 +43,7 @@ const { response, loading } = defineProps({
 
     <div class="flex flex-col gap-2">
       <div v-if="response" class="text-sm text-muted-foreground">
-        {{ $t('Response time') }}: {{ loading ? $t('Loading') : `${response.time}ms` }}
+        {{ t('Response time') }}: {{ loading ? t('Loading') : `${response.time}ms` }}
       </div>
 
       <div class="flex flex-col max-h-96 overflow-y-auto">

--- a/src/components/Playground/OAPlaygroundResponseContent.vue
+++ b/src/components/Playground/OAPlaygroundResponseContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps, onBeforeUnmount, ref, watch } from 'vue'
 import OACodeBlock from '../Common/OACodeBlock.vue'
 
@@ -11,6 +12,8 @@ interface ResponseType {
 const props = defineProps<{
   response: ResponseType
 }>()
+
+const { t } = useI18n()
 
 const isType = (regex: RegExp) => computed(() => regex.test(props.response.type))
 
@@ -118,17 +121,17 @@ const downloadBlob = (blob: Blob, fileName: string) => {
     <img
       v-else-if="isImage"
       :src="props.response.body"
-      :alt="$t('Response Image')"
+      :alt="t('Response Image')"
       style="max-width: 100%;"
     >
     <audio
       v-else-if="isAudio"
       controls
       class="w-full mt-2"
-      :aria-label="$t('Audio response')"
+      :aria-label="t('Audio response')"
     >
       <source :src="audioUrl" :type="props.response.type">
-      {{ $t('Your browser does not support the audio element.') }}
+      {{ t('Your browser does not support the audio element.') }}
     </audio>
     <div v-else-if="isDownloadable">
       <button
@@ -136,11 +139,11 @@ const downloadBlob = (blob: Blob, fileName: string) => {
         aria-label="Download file"
         @click="downloadBlob(props.response.body, 'response_file')"
       >
-        {{ $t('Download file') }}
+        {{ t('Download file') }}
       </button>
     </div>
     <div v-else>
-      <p>{{ $t('Unrecognized response type. Raw content:') }}</p>
+      <p>{{ t('Unrecognized response type. Raw content:') }}</p>
       <pre class="whitespace-pre-wrap">{{ props.response.body }}</pre>
     </div>
   </div>

--- a/src/components/Request/OARequestBody.vue
+++ b/src/components/Request/OARequestBody.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { OperationData } from '../../lib/operationData'
 import type { OARequestBody } from '../../types'
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, inject } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import { OPERATION_DATA_KEY } from '../../lib/operationData'
@@ -28,6 +29,7 @@ const defaultView = useTheme().getRequestBodyDefaultView()
 const contentTypeId = `request-body-content-type-${props.operationId}`
 
 const operationData = inject(OPERATION_DATA_KEY) as OperationData
+const { t } = useI18n()
 
 const contentType = computed({
   get: () => operationData.requestBody.selectedContentType.value,
@@ -69,7 +71,7 @@ const examples = computed(() => {
         class="text-[var(--vp-c-text-1)] !my-0 !py-0 !border-t-0 inline-block"
         header-anchor-class="!top-0"
       >
-        {{ $t('Request Body') }}
+        {{ t('Request Body') }}
       </OAHeading>
       <div class="relative flex-1">
         <div class="absolute inset-x-0 top-[-14px] w-full flex justify-end">

--- a/src/components/Response/OAResponse.vue
+++ b/src/components/Response/OAResponse.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps, ref } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import OAContentTypeSelect from '../Common/OAContentTypeSelect.vue'
@@ -31,6 +32,7 @@ const examples = computed(() => props.response.content?.[contentType.value]?.exa
 const contentTypeId = `content-type-${Math.random().toString(36).substring(7)}`
 
 const defaultView = useTheme().getResponseBodyDefaultView()
+const { t } = useI18n()
 </script>
 
 <template>
@@ -45,7 +47,7 @@ const defaultView = useTheme().getResponseBodyDefaultView()
         :for="contentTypeId"
         class="flex-shrink-0 text-muted-foreground"
       >
-        {{ $t('Content-Type') }}
+        {{ t('Content-Type') }}
       </Label>
       <div class="flex-shrink-0">
         <OAContentTypeSelect

--- a/src/components/Response/OAResponses.vue
+++ b/src/components/Response/OAResponses.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { TabsIndicator } from 'reka-ui'
 import { computed, defineProps, ref } from 'vue'
 import { useTheme } from '../../composables/useTheme'
@@ -23,6 +24,7 @@ const props = defineProps({
 })
 
 const themeConfig = useTheme()
+const { t } = useI18n()
 
 const responsesCodes = Object.keys(props.responses)
 
@@ -53,7 +55,7 @@ const tabsSelector = computed(() => {
           class="text-[var(--vp-c-text-1)] !my-0 !py-0 !border-t-0 inline-block"
           header-anchor-class="!top-0"
         >
-          {{ $t('Responses') }}
+          {{ t('Responses') }}
         </OAHeading>
         <div class="relative flex-1">
           <div class="absolute inset-x-0 top-[-20px] w-full flex justify-end">

--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed } from 'vue'
 import { useTheme } from '../../composables/useTheme'
 import OACodeBlock from '../Common/OACodeBlock.vue'
@@ -22,6 +23,7 @@ const props = defineProps({
 })
 
 const schemaViewerDeep = useTheme().getSchemaViewerDeep()
+const { t } = useI18n()
 
 const defaultValue = computed(() => {
   const examplesKeys = Object.keys(props.examples ?? {})
@@ -50,7 +52,7 @@ const defaultValue = computed(() => {
         variant="schemaTabs"
         class="h-full"
       >
-        {{ $t('Schema') }}
+        {{ t('Schema') }}
       </TabsTrigger>
       <TabsTrigger
         v-for="(_, exampleKey) in props.examples ?? {}"

--- a/src/components/Schema/OASchemaUI.vue
+++ b/src/components/Schema/OASchemaUI.vue
@@ -100,7 +100,7 @@ const unionBadge = computed(() => {
                       v-if="isObjectOrArray && props.property.properties"
                       size="icon"
                       variant="icon"
-                      :aria-label="isOpen ? $t('Collapse') : $t('Expand')"
+                      :aria-label="isOpen ? t('Collapse') : t('Expand')"
                       class="flex-shrink-0 w-4 h-4 cursor-pointer"
                     >
                       <ChevronDown v-if="isOpen" />
@@ -108,7 +108,7 @@ const unionBadge = computed(() => {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{{ isOpen ? $t('Collapse') : $t('Expand') }}</p>
+                    <p>{{ isOpen ? t('Collapse') : t('Expand') }}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -119,7 +119,7 @@ const unionBadge = computed(() => {
                 v-if="props.property.meta?.isCircularReference === true"
                 variant="outline"
               >
-                {{ $t('Circular Reference') }}
+                {{ t('Circular Reference') }}
               </Badge>
               <template v-else-if="props.property.types.length === 1 && ['array'].includes(props.property.types[0]) && props.property.subtype">
                 <span>{{ props.property.subtype }}[]</span>
@@ -128,7 +128,7 @@ const unionBadge = computed(() => {
                 <span>{{ props.property.subtype }}</span>
               </template>
               <template v-else-if="props.property.meta?.isConstant === true">
-                <span>{{ $t('const:') }}</span>
+                <span>{{ t('const:') }}</span>
                 <span v-if="props.property.examples?.length > 0" class="select-all">{{ props.property.examples[0] }}</span>
               </template>
               <template v-else>
@@ -149,7 +149,7 @@ const unionBadge = computed(() => {
                     <Button
                       size="icon"
                       variant="icon"
-                      :aria-label="isOpen ? $t('Collapse all') : $t('Expand all')"
+                      :aria-label="isOpen ? t('Collapse all') : t('Expand all')"
                       @click.stop.prevent="toggleAllChildren(!isOpen)"
                     >
                       <Minimize2 v-if="isOpen" />
@@ -157,7 +157,7 @@ const unionBadge = computed(() => {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{{ isOpen ? $t('Collapse all') : $t('Expand all') }}</p>
+                    <p>{{ isOpen ? t('Collapse all') : t('Expand all') }}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -171,7 +171,7 @@ const unionBadge = computed(() => {
             </div>
 
             <span class="text-red-800 dark:text-red-200 text-xs">{{
-              props.property.required === true ? $t('Required') : ''
+              props.property.required === true ? t('Required') : ''
             }}</span>
           </div>
 
@@ -184,7 +184,7 @@ const unionBadge = computed(() => {
             }"
           />
 
-          <OASchemaPropertyAttributes v-if="props.property.enum" :property="{ [$t('valid values')]: props.property.enum }" />
+          <OASchemaPropertyAttributes v-if="props.property.enum" :property="{ [t('valid values')]: props.property.enum }" />
 
           <OASchemaPropertyAttributes v-if="props.property.constraints" :property="props.property.constraints" />
         </div>

--- a/src/components/Security/OASecurity.vue
+++ b/src/components/Security/OASecurity.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { defineProps } from 'vue'
 import OAHeading from '../Common/OAHeading.vue'
 import OASecurityContent from '../Security/OASecurityContent.vue'
@@ -19,6 +20,8 @@ const props = defineProps({
     default: '',
   },
 })
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -31,7 +34,7 @@ const props = defineProps({
           class="text-[var(--vp-c-text-1)] !my-0 !py-0 !border-t-0"
           header-anchor-class="!top-0"
         >
-          {{ $t('Authorizations') }}
+          {{ t('Authorizations') }}
         </OAHeading>
 
         <span class="flex-grow min-w-2" />
@@ -73,7 +76,7 @@ const props = defineProps({
         </div>
 
         <div v-if="Number(key) < Object.keys(props.securityUi).length - 1" class="flex flex-row items-center space-x-2">
-          <span class="text-sm font-bold">{{ $t('or') }}</span>
+          <span class="text-sm font-bold">{{ t('or') }}</span>
           <span class="flex-grow border-t border-[var(--vp-c-divider)]" />
         </div>
       </div>

--- a/src/components/Security/OASecurityContent.vue
+++ b/src/components/Security/OASecurityContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from '@byjohann/vue-i18n'
 import { computed, defineProps } from 'vue'
 import OACodeValue from '../Common/OACodeValue.vue'
 import OAMarkdown from '../Common/OAMarkdown.vue'
@@ -15,6 +16,8 @@ const { scheme, name } = defineProps({
     required: true,
   },
 })
+
+const { t } = useI18n()
 
 const typeValue = computed(() => {
   if (scheme.type === 'http') {
@@ -52,7 +55,7 @@ const typeValue = computed(() => {
     </div>
 
     <div class="flex flex-col gap-2">
-      <OAParameterAttribute v-if="scheme.type !== 'oauth2'" :name="$t('Type')" bold-name :value="typeValue" />
+      <OAParameterAttribute v-if="scheme.type !== 'oauth2'" :name="t('Type')" bold-name :value="typeValue" />
 
       <div
         v-if="scheme.type === 'oauth2'"
@@ -69,12 +72,12 @@ const typeValue = computed(() => {
 
             <div class="pl-2 flex flex-col gap-1">
               <div v-if="url.authorizationUrl" class="flex flex-wrap gap-2">
-                <span class="text-sm">{{ $t('Authorization URL') }}</span>
+                <span class="text-sm">{{ t('Authorization URL') }}</span>
                 <OACodeValue :value="url.authorizationUrl" />
               </div>
 
               <div v-if="url.tokenUrl" class="flex flex-wrap gap-2">
-                <span class="text-sm">{{ $t('Token URL') }}</span>
+                <span class="text-sm">{{ t('Token URL') }}</span>
                 <OACodeValue :value="url.tokenUrl" />
               </div>
 

--- a/src/components/ui/select-with-custom-option/SelectWithCustomOption.vue
+++ b/src/components/ui/select-with-custom-option/SelectWithCustomOption.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { WritableComputedRef } from 'vue'
 import type { SelectWithCustomOptionEmits, SelectWithCustomOptionProps } from './index'
+import { useI18n } from '@byjohann/vue-i18n'
 import { useVModel } from '@vueuse/core'
 import { computed, watch } from 'vue'
 import { Input } from '../input'
@@ -24,6 +25,8 @@ const CUSTOM_VALUE = 'custom'
 const value: WritableComputedRef<string> = useVModel(props, 'modelValue', emit)
 const isCustom: WritableComputedRef<boolean> = useVModel(props, 'isCustom', emit)
 const customValue: WritableComputedRef<string | undefined> = useVModel(props, 'customValue', emit)
+
+const { t } = useI18n()
 
 watch(customValue, (newValue) => {
   if (newValue === undefined) {
@@ -75,7 +78,7 @@ const handleSelectChange = (selectedValue: string) => {
       class="absolute inset-0"
       @update:model-value="handleSelectChange(String($event))"
     >
-      <SelectTrigger :aria-label="$t('Select')">
+      <SelectTrigger :aria-label="t('Select')">
         <SelectValue :placeholder="placeholder" class="text-start" />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## Summary
- get translation function via `useI18n` in all components
- replace `{{ $t(...) }}` with `{{ t(...) }}`
- keep theme i18n setup the same

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_686f0f16b97c832d89ee1279c6ad3502