### PR TITLE
Add markdown setup hook and disable operation links

### DIFF
--- a/docs/composables/useTheme.md
+++ b/docs/composables/useTheme.md
@@ -136,6 +136,7 @@ export default {
                     },
                 },
                 externalLinksNewTab: true,
+                setup: md => md,
             },
         })
     }
@@ -221,7 +222,7 @@ export default {
 
 | Function              | Description                       | Default Value                                                | Allowed Values                                                                                                                                                                    |
 |------------------------|-----------------------------------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }`            |
-| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }, externalLinksNewTab: boolean }` |
+| `setMarkdownConfig`    | Sets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } \| false, externalLinksNewTab: boolean, setup: (md) => MarkdownIt }`            |
+| `getMarkdownConfig`    | Gets the markdown configuration.  | `{ operationLink: { linkPrefix: '/operations/' }, externalLinksNewTab: false }`        | `{ operationLink: { linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string } \| false, externalLinksNewTab: boolean, setup: (md) => MarkdownIt }` |
 | `getOperationLinkConfig` | Gets the operation link configuration. | `{ linkPrefix: '/operations/' }`                    | `{ linkPrefix: string, transformHref: (href: string) => string, createOperationLinkHtml: (href: string, method: string, title: string) => string }`                    |
 | `getExternalLinksNewTab` | Gets whether external links open in new tab. | `false` | `true`, `false` |

--- a/src/composables/useMarkdown.ts
+++ b/src/composables/useMarkdown.ts
@@ -6,9 +6,9 @@ import { useTheme } from './useTheme'
 export function useMarkdown() {
   const theme = useTheme()
   const operationLinkConfig = theme.getOperationLinkConfig()
-  const { externalLinksNewTab } = theme.getMarkdownConfig()
+  const { externalLinksNewTab, setup } = theme.getMarkdownConfig()
 
-  const md = markdownit({
+  let md = markdownit({
     html: true,
     breaks: true,
   })
@@ -27,7 +27,14 @@ export function useMarkdown() {
     ])
   }
 
-  md.use(operationLink, operationLinkConfig)
+  if (operationLinkConfig !== false) {
+    md.use(operationLink, operationLinkConfig)
+  }
+
+  if (setup) {
+    // user can mutate existing md to add plugins or return completely different instance
+    md = setup(md) || md
+  }
 
   function render(content: string) {
     // Ensure we always return a valid HTML string even for empty/undefined content.

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,3 +1,4 @@
+import type MarkdownIt from 'markdown-it'
 import type { Ref, UnwrapNestedRefs } from 'vue'
 import type { OARequest } from '../lib/codeSamples/request'
 import type { OperationSlot, ParsedOperation } from '../types'
@@ -149,8 +150,9 @@ export interface OperationLinkConfig {
 }
 
 export interface MarkdownConfig {
-  operationLink?: OperationLinkConfig
+  operationLink?: OperationLinkConfig | false
   externalLinksNewTab?: boolean
+  setup?: (md: MarkdownIt) => MarkdownIt | void
 }
 
 export interface UseThemeConfig {
@@ -360,6 +362,7 @@ const defaultValues = {
       linkPrefix: DEFAULT_OPERATIONS_PREFIX,
     },
     externalLinksNewTab: false,
+    setup: undefined,
   },
 }
 
@@ -449,6 +452,7 @@ const themeConfig: UseThemeConfig = {
       linkPrefix: defaultValues.markdown.operationLink.linkPrefix,
     },
     externalLinksNewTab: defaultValues.markdown.externalLinksNewTab,
+    setup: defaultValues.markdown.setup,
   },
 }
 
@@ -1019,24 +1023,32 @@ export function useTheme(initialConfig: PartialUseThemeConfig = {}) {
   function setMarkdownConfig(config: Partial<UnwrapNestedRefs<MarkdownConfig>>) {
     const markdown = ensureNestedProperty(themeConfig, 'markdown')
 
-    if (config.operationLink) {
-      const operationLink = ensureNestedProperty(markdown, 'operationLink')
+    if (config.operationLink !== undefined) {
+      if (config.operationLink === false) {
+        markdown.operationLink = false
+      } else {
+        const operationLink = ensureNestedProperty(markdown, 'operationLink')
 
-      if (config.operationLink.linkPrefix !== undefined) {
-        operationLink.linkPrefix = config.operationLink.linkPrefix
-      }
+        if (config.operationLink.linkPrefix !== undefined) {
+          operationLink.linkPrefix = config.operationLink.linkPrefix
+        }
 
-      if (config.operationLink.transformHref !== undefined) {
-        operationLink.transformHref = config.operationLink.transformHref
+        if (config.operationLink.transformHref !== undefined) {
+          operationLink.transformHref = config.operationLink.transformHref
+        }
       }
     }
 
     if (config.externalLinksNewTab !== undefined) {
       markdown.externalLinksNewTab = config.externalLinksNewTab
     }
+
+    if (config.setup !== undefined) {
+      markdown.setup = config.setup
+    }
   }
 
-  function getOperationLinkConfig(): OperationLinkConfig | undefined {
+  function getOperationLinkConfig(): OperationLinkConfig | false | undefined {
     return themeConfig.markdown?.operationLink
   }
 

--- a/test/composables/useMarkdown.test.ts
+++ b/test/composables/useMarkdown.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import MarkdownIt from 'markdown-it'
 import { useMarkdown } from '../../src/composables/useMarkdown'
 import { useTheme } from '../../src/composables/useTheme'
+import { useOpenapi } from '../../src/composables/useOpenapi'
+import { spec } from '../testsConstants'
 
 describe('useMarkdown', () => {
   it('should return a markdown-it instance', () => {
@@ -34,5 +37,25 @@ describe('useMarkdown', () => {
     const { render } = useMarkdown()
     const result = render('[link](https://example.com)')
     expect(result).toContain('target="_blank"')
+  })
+
+  it('does not transform operation links when disabled', () => {
+    const theme = useTheme()
+    theme.reset()
+    theme.setMarkdownConfig({ operationLink: false })
+    useOpenapi({ spec })
+    const { render } = useMarkdown()
+    const result = render('[Get Users](/operations/getUsers)')
+    expect(result).toContain('<a href="/operations/getUsers">Get Users</a>')
+    expect(result).not.toContain('OAOperationLink')
+  })
+
+  it('calls setup function from markdown config', () => {
+    const theme = useTheme()
+    theme.reset()
+    const setup = vi.fn((md: MarkdownIt) => md)
+    theme.setMarkdownConfig({ setup })
+    useMarkdown()
+    expect(setup).toHaveBeenCalled()
   })
 })

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -768,6 +768,19 @@ describe('markdown configuration', () => {
     const result = themeConfig.getExternalLinksNewTab()
     expect(result).toBe(true)
   })
+
+  it('allows disabling operation link processing', () => {
+    themeConfig.setMarkdownConfig({ operationLink: false })
+    const result = themeConfig.getOperationLinkConfig()
+    expect(result).toBe(false)
+  })
+
+  it('stores the markdown setup callback', () => {
+    const setup = () => {}
+    themeConfig.setMarkdownConfig({ setup })
+    const result = themeConfig.getMarkdownConfig()
+    expect(result.setup).toBe(setup)
+  })
 })
 
 describe('codeSamples configuration', () => {


### PR DESCRIPTION
## Summary
- allow disabling `operationLink` plugin and configure a setup function for customizing MarkdownIt
- update `useTheme` to handle new markdown config options
- update docs to show markdown setup usage
- test disabling operation links and markdown setup

## Testing
- `pnpm lint`
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_6872d86521d0832db837a8cd2a6a7a66